### PR TITLE
Corrected refresh parameter in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ _, err = client.Index().
     Type("tweet").
     Id("1").
     BodyJson(tweet).
-    Refresh(true).
+    Refresh("true").
     Do(ctx)
 if err != nil {
     // Handle error


### PR DESCRIPTION
For a reason that is not obvious to me, v5 now accepts a string for the refresh parameter of func (s *ExistsService) Refresh instead of the previous bool in v4 while RealTime is still a bool. The example had not been updated to account for this difference. 

This requests updates the example within the v5 branch to be correct with the v5 code. 